### PR TITLE
Enable pretrained weight loading for YOLO12 training

### DIFF
--- a/configs/yolo12_training_config.yaml
+++ b/configs/yolo12_training_config.yaml
@@ -2,13 +2,9 @@
 # Based on Ultralytics YOLO12 configuration - Latest and most advanced model
 
 # Model Configuration
-model:
-  architecture: "yolo12s"  # YOLO12 small (detection model)
-  # Options: yolo12n, yolo12s, yolo12m, yolo12l, yolo12x
-  # Note: YOLO12 models are detection models, not segmentation models
-  # For segmentation, consider YOLOv8-seg models
-  pretrained: true
-  freeze_backbone: false
+model: "models/yolo12_coco_pretrained.pt"  # Path to pretrained YOLO12 weights
+pretrained: true
+freeze_backbone: false
 
 # Dataset Configuration
 dataset:

--- a/scripts/train_yolo12.py
+++ b/scripts/train_yolo12.py
@@ -35,6 +35,12 @@ def main():
         default='n',
         help="YOLO12 model size: n(nano), s(small), m(medium), l(large), x(extra-large) (default: n)"
     )
+
+    parser.add_argument(
+        "--pretrained",
+        type=str,
+        help="Path to pretrained YOLO12 weights to load before training",
+    )
     
     parser.add_argument(
         "--epochs",
@@ -97,9 +103,14 @@ def main():
     trainer.config['training']['imgsz'] = args.image_size
     trainer.config['training']['device'] = args.device
     
-    # Set model architecture based on size
-    model_architecture = f"yolo12{args.model_size}"  # YOLO12 models don't have -seg.pt suffix
-    trainer.config['model']['architecture'] = model_architecture
+    # Determine model architecture or pretrained weights
+    if args.pretrained:
+        model_architecture = args.pretrained
+    else:
+        model_architecture = f"yolo12{args.model_size}"
+
+    # Store selected model path in configuration
+    trainer.config['model'] = model_architecture
     
     print(f"\n=== YOLO12 Training Configuration ===")
     print(f"Model: {model_architecture}")


### PR DESCRIPTION
## Summary
- point training config to a pretrained YOLO12 checkpoint
- add `--pretrained` flag in training script to load custom weights before training

## Testing
- `pytest -q` *(fails: ImportError: libGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_689ff114e7908322b31034badff56cd7